### PR TITLE
Fixing `blackhole.webm` video display on ultrawide screens

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,7 +20,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${inter.className} bg-[#030014] overflow-y-scroll overflow-x-hidden`}
+        className={`${inter.className} bg-[#030014] overflow-y-scroll overflow-x-hidden max-w-[1855px] mx-auto`}
       >
         <StarsCanvas />
         <Navbar />

--- a/components/main/Navbar.tsx
+++ b/components/main/Navbar.tsx
@@ -4,7 +4,7 @@ import React from "react";
 
 const Navbar = () => {
   return (
-    <div className="w-full h-[65px] fixed top-0 shadow-lg shadow-[#2A0E61]/50 bg-[#03001417] backdrop-blur-md z-50 px-10">
+    <div className="w-full h-[65px] fixed top-0 shadow-lg shadow-[#2A0E61]/50 bg-[#03001417] backdrop-blur-md z-50 px-10 max-w-[1855px] items-center rounded-full">
       <div className="w-full h-full flex flex-row items-center justify-between m-auto px-[10px]">
         <a
           href="#about-me"


### PR DESCRIPTION
# Details

I really enjoyed your video about this project and decided to test it on my PC. However, I noticed that the black hole video was not displaying correctly on ultrawide monitors.

As a result, I made a small adjustment that sets a size limit for the content to be displayed. This prevents the user experience from being compromised when using monitors with a 21:9 aspect ratio.

<hr>

## Before adjustments

![WebChain - before](https://github.com/Mif2006/Space-Portolio/assets/74682858/6ebda157-6040-41ac-8b58-d0980349ec3b)

## After adjustments

![WebChain - after](https://github.com/Mif2006/Space-Portolio/assets/74682858/a99a6b36-37b1-43bf-95e9-a62ebc0034ed)

